### PR TITLE
Fixing ShapeLayer’s ridiculous geometry semantics 😂

### DIFF
--- a/Prototope/Layer.swift
+++ b/Prototope/Layer.swift
@@ -37,7 +37,7 @@ public class Layer: Equatable {
 	public class var root: Layer! { return Environment.currentEnvironment?.rootLayer }
 
 	/** Creates a layer with an optional parent and name. */
-	public init(parent: Layer? = Layer.root, name: String? = nil, viewClass: SystemView.Type? = nil) {
+	public init(parent: Layer? = Layer.root, name: String? = nil, viewClass: SystemView.Type? = nil, frame: Rect? = nil) {
 		self.parent = parent ?? Layer.root
 		self.name = name
 
@@ -54,7 +54,7 @@ public class Layer: Equatable {
 
 		self.parentDidChange()
 
-		self.frame = Rect(x: 0, y: 0, width: 100, height: 100)
+		self.frame = frame ?? Rect(x: 0, y: 0, width: 100, height: 100)
 	}
 
 	/** Convenience initializer; makes a layer which displays an image by name.

--- a/Prototope/ShapeLayer.swift
+++ b/Prototope/ShapeLayer.swift
@@ -24,37 +24,35 @@ public class ShapeLayer: Layer {
 	
 	
 	/** Creates an oval within the given rectangle. */
-	convenience public init(ovalInRectangle: Rect, parent: Layer? = nil, name: String? = nil) {
-		var renderRect = ovalInRectangle
-		renderRect.origin = Point()
-		self.init(segments: Segment.segmentsForOvalInRect(renderRect), closed: true, parent: parent, name: name)
-		self.frame = ovalInRectangle
+	convenience public init(ovalInRectangle ovalRect: Rect, parent: Layer? = nil, name: String? = nil) {
+		self.init(segments: Segment.segmentsForOvalInRect(ovalRect), closed: true, parent: parent, name: name)
 	}
 	
 	
 	/** Creates a rectangle with an optional corner radius. */
 	convenience public init(rectangle: Rect, cornerRadius: Double = 0, parent: Layer? = nil, name: String? = nil) {
-		var renderRect = rectangle
-		renderRect.origin = Point()
-		self.init(segments: Segment.segmentsForRect(renderRect, cornerRadius: cornerRadius), closed: true, parent: parent, name: name)
-//		self.frame = rectangle
+		self.init(segments: Segment.segmentsForRect(rectangle, cornerRadius: cornerRadius), closed: true, parent: parent, name: name)
 	}
 	
 	
 	/** Creates a line from two points. */
 	convenience public init(lineFromFirstPoint firstPoint: Point, toSecondPoint secondPoint: Point, parent: Layer? = nil, name: String? = nil) {
-//		let difference = secondPoint - firstPoint
 		self.init(segments: Segment.segmentsForLineFromFirstPoint(firstPoint, secondPoint: secondPoint), parent: parent, name: name)
-//		self.frame = Rect(x: firstPoint.x, y: firstPoint.y, width: abs(difference.x), height: abs(difference.y))
 	}
 	
 	
 	/** Creates a regular polygon path with the given number of sides. */
 	convenience public init(polygonCenteredAtPoint centerPoint: Point, radius: Double, numberOfSides: Int, parent: Layer? = nil, name: String? = nil) {
-		let frame = Rect(x: centerPoint.x - radius, y: centerPoint.y - radius, width: radius * 2, height: radius * 2)
-        self.init(segments: Segment.segmentsForPolygonCenteredAtPoint(Point(x: radius, y: radius), radius: radius, numberOfSides: numberOfSides), closed: true, parent: parent, name: name)
-        
-		self.frame = frame
+        self.init(
+			segments: Segment.segmentsForPolygonCenteredAtPoint(
+				Point(x: radius, y: radius),
+				radius: radius,
+				numberOfSides: numberOfSides
+			),
+			closed: true,
+			parent: parent,
+			name: name
+		)
 	}
 	
 	
@@ -73,29 +71,26 @@ public class ShapeLayer: Layer {
 		
 		let view = self.view as! ShapeView
 		view.displayHandler = {
-//			[weak self] in
-//			if let aliveSelf = self {
-//				aliveSelf.shapeViewLayer.path = aliveSelf.bezierPath.CGPath
-//			}
+			// todo(jb): probably get rid of this mechanism.
+			// but, I'd like to explore if it'll work (updating segments + bounds + position in this handler)
+			// but for now, don't wait for the needs display loop, and just force the changes.
 		}
 		segmentsDidChange()
-		self.setNeedsDisplay()
 		self.shapeViewLayerStyleDidChange()
-		
 	}
 	
 	
 	// MARK: - Segments
 	
-	/** A list of all segments of this path. */
+	/** A list of all segments of this path.
+		Segments are in the **parent layer's** coordinate space, which feels similar to drawing tools, but is different from the default `CAShapeLayer` behaviour, which is ridiculous. */
 	public var segments: [Segment] {
 		didSet {
-//			self.setNeedsDisplay()
-			print("settings segments")
 			segmentsDidChange()
 		}
 	}
 	
+	/** Private structure to hold a path and its bounds. */
 	private struct PathCache {
 		let path: UIBezierPath
 		let bounds: Rect
@@ -106,7 +101,6 @@ public class ShapeLayer: Layer {
 	private var _pathCache: PathCache
 	
 	private func segmentsDidChange() {
-		print("segments did change")
 		
 		let path = ShapeLayer.bezierPathForSegments(segments, closedPath: closed)
 		let bounds = Rect(CGPathGetPathBoundingBox(path.CGPath))
@@ -119,15 +113,12 @@ public class ShapeLayer: Layer {
 		self.position = bounds.center
 	}
 	
+	/** Sets the layer's bounds. The given rect must match the bounds of the `segments`'s path.
+		Generally speaking, you should not need to call this directly. */
 	public override var bounds: Rect {
-		get {
-			print("getting bounds")
-			return super.bounds
-		}
+		get { return super.bounds }
 		
 		set {
-			print("setting bounds")
-			
 			let pathBounds = _pathCache.bounds
 			
 			precondition(newValue == pathBounds, "Attempting to set bounds to a rect that doesn't match the layer's path's bounds")
@@ -137,14 +128,12 @@ public class ShapeLayer: Layer {
 	}
 	
 	
+	/** Sets the layer's position (by default, its centre point).
+		Setting this has the effect of translating the layer's `segments` so they match the new geometry. */
 	public override var position: Point {
-		get {
-			print("getting position")
-			return super.position
-		}
+		get { return super.position }
 		
 		set {
-			print("setting position")
 			let oldPosition = super.position
 			super.position = newValue
 			
@@ -153,7 +142,6 @@ public class ShapeLayer: Layer {
 			
 			if pathBounds.center != newValue {
 				let positionDelta = newValue - oldPosition
-				print("setting new position value:\(newValue), updating segments by delta: \(positionDelta)")
 				
 				segments = segments.map {
 					var segment = $0
@@ -166,14 +154,12 @@ public class ShapeLayer: Layer {
 	}
 	
 	
+	/** Sets the layer's frame. The given rect's size must match the size of the `segments`'s path's bounds.
+		Setting this has the effect of translating the layer's `segments` so they match the new geometry. */
 	public override var frame: Rect {
-		get {
-			print("getting frame")
-			return super.frame
-		}
+		get { return super.frame }
 		
 		set {
-			print("setting frame")
 			
 			let pathBounds = _pathCache.bounds
 			
@@ -185,7 +171,6 @@ public class ShapeLayer: Layer {
 			
 			if pathBounds.center != newValue.center {
 				let positionDelta = newValue.center - oldFrame.center
-				print("setting new frame center value:\(newValue), updating segments by delta: \(positionDelta)")
 				
 				segments = segments.map {
 					var segment = $0
@@ -193,7 +178,6 @@ public class ShapeLayer: Layer {
 					return segment
 				}
 			}
-			
 		}
 	}
 	


### PR DESCRIPTION
This fixes a longstanding issue with ShapeLayer: in brief, `CAShapeLayer`, which `ShapeLayer` uses under the hood, has the ghastly semantics such that its `path` is rendered in the shape layer’s coordinate space, instead of the super layer’s coordinate space. That means if you give it a rect path starting at (100, 100), it’ll draw 100, 100 offset from the _layer’s_ origin, and the layer’s `position` and `bounds` (and .: `frame`) will be unaffected. (See #4 for more details).

Anyway, the solution is essentially:
- when the `segments` are changed, recompute the path, set it to the underlying `CAShapeLayer`, then update `bounds` and `position` with the bounds of the path.
- don’t allow `bounds` to be changed unless it matches the bounds of the path
- when `position` is updated, check to see if we need to translate the `segments` (be careful not to infinitely recurse)
- don’t allow `frame` to be changed unless its `size` matches the size of the bounds of the path
- when `frame` is updated, check to see if we need to translate the `segments` (again, being careful not to infinitely recurse).

There’s a little bit of housekeeping involved in this, mostly fixing the convenience initializers for various shapes, which were previously hacked around this weird geometry issue (they basically manually set the frame of what you’d expect, which was nice, but you still couldn’t meaningfully change the shape after the fact).

I also cache the path and its bounds now, to save a bit of computation (but mostly just for better factoring). Finally, `Layer.init` now takes an optional frame, and uses that if present (else it just sets a default value, like always).
